### PR TITLE
Resolves #4 - update how the extension detects notification counters

### DIFF
--- a/background.js
+++ b/background.js
@@ -54,9 +54,13 @@ chrome.tabs.onUpdated.addListener(async (tabId, changeInfo, tab) => {
 // function to remove '(x)' from the beginning of a tab's title
 function removeNotificationCounter() {
     let title = document.title;
-    if(title[0] === '(' && title.includes(')')) {
-        let idx = title.indexOf(')');
-        title = title.slice(idx+1).trim();
+
+    let l = title.indexOf('(')
+    let r = title.indexOf(')')
+    if (l !== -1 && r !== -1 && l < r) {
+        toRemove = title.slice(l, r+1)
+        title = title.replace(toRemove, "").replace("  ", " ").trim()
     }
+
     document.title = title;
 }

--- a/manifest.json
+++ b/manifest.json
@@ -2,7 +2,7 @@
     "name": "No Notif Counter",
     "author": "Nigel Davis",
     "description": "Chrome extenstion that removes the notification counter in tab titles",
-    "version": "1.0",
+    "version": "1.1",
     "manifest_version": 3,
     "background": {
         "service_worker": "background.js"

--- a/popup.js
+++ b/popup.js
@@ -45,10 +45,14 @@ toggle.addEventListener('change', async () => {
 // function to remove '(x)' from the beginning of a tab's title
 function removeNotificationCounter() {
     let title = document.title;
-    if(title[0] === '(' && title.includes(')')) {
-        let idx = title.indexOf(')');
-        title = title.slice(idx+1).trim();
+
+    let l = title.indexOf('(')
+    let r = title.indexOf(')')
+    if (l !== -1 && r !== -1 && l < r) {
+        toRemove = title.slice(l, r+1)
+        title = title.replace(toRemove, "").replace("  ", " ").trim()
     }
+
     document.title = title;
 }
 


### PR DESCRIPTION
Slightly modified the string manipulation function that removes the notification counter to work with more sites. More specifically, sites that don't have the counter at the very beginning of the title

### Implementation

- instead of just checking at the beginning I generally check if the title contains any string matching "(x)" in the title and then remove it
- the new method like the old is a little jank but it does the job. All other ways I tried to do this weren't working (ie. regex)
- tried also to clean up the code as this project is almost two years old but for some reason importing functions from separate files for chrome extensions doesn't work easily